### PR TITLE
shorten loadBalancerName

### DIFF
--- a/aws/src/script/deploy.ts
+++ b/aws/src/script/deploy.ts
@@ -11,7 +11,7 @@ import { ensureService } from '../ecs/service';
 import * as winston from 'winston';
 
 
-export const loadBalancerName = 'honesty-store';
+export const loadBalancerName = 'hs';
 export const defaultTargetGroupDir = 'web';
 export const role = 'arn:aws:iam::812374064424:role/ecs-service-role';
 export const cluster = 'test-cluster';


### PR DESCRIPTION
This uses less of the 32-character target-group-name limit, permitting
us to use longer branch names.