### PR TITLE
waitFor() tasks to be running before ensureService returns successfully

### DIFF
--- a/aws/src/ecs/service.ts
+++ b/aws/src/ecs/service.ts
@@ -1,5 +1,6 @@
 import { ECS } from 'aws-sdk';
 import * as winston from 'winston';
+import { awsCheckFailures } from '../failure';
 
 /*
 requires:
@@ -40,6 +41,15 @@ export const ensureService = async (serviceRequest: ECS.CreateServiceRequest) =>
     const service = updateResponse.service;
 
     winston.debug('service: updateService', service);
+
+    const waitResponse = await ecs.waitFor('tasksRunning', {
+      cluster: serviceRequest.cluster,
+      tasks: [serviceRequest.taskDefinition]
+    })
+      .promise();
+
+    awsCheckFailures(waitResponse);
+    // no failures - task(s) are running
 
     return service;
   }


### PR DESCRIPTION
An attempt at fixing #7 