### PR TITLE
ensure transaction amounts are numbers

### DIFF
--- a/transaction/src/index.ts
+++ b/transaction/src/index.ts
@@ -32,6 +32,9 @@ const assertValidTransaction = ({type, amount, data}: Transaction) => {
     if (type == null || (type !== 'topup' && type !== 'purchase')) {
         throw new Error(`Invalid transaction type ${type}`);
     }
+    if (!Number.isInteger(amount) /* this also checks typeof amount */) {
+        throw new Error(`Non-integral transaction amount ${amount}`);
+    }
     if ((type === 'topup' && amount <= 0) || (type === 'purchase' && amount >= 0)) {
         throw new Error(`Invalid transaction amount for type ${amount} ${type}`);
     }


### PR DESCRIPTION
A String amount was sneaking through, leading to 500 + 30 -> 50030.
https://eu-west-1.console.aws.amazon.com/dynamodb/home?region=eu-west-1#tables:selected=hs-topup-transaction

Catch this, along with NaN and Inf.