### PR TITLE
Update api service dependencies

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -11,20 +11,20 @@
   },
   "dependencies": {
     "body-parser": "^1.15.2",
-    "chai": "^3.5.0",
     "express": "^4.14.0",
     "http-status": "^0.2.3",
     "jsonwebtoken": "^7.2.1",
-    "mocha": "^3.2.0",
-    "request": "^2.79.0",
     "uuid": "^3.0.1",
     "validator": "^6.2.0",
     "winston": "^2.3.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint": "^3.12.1",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "nodemon": "^1.11.0"
+    "mocha": "^3.2.0",
+    "nodemon": "^1.11.0",
+    "request": "^2.79.0"
   }
 }

--- a/api/test/.eslintrc
+++ b/api/test/.eslintrc
@@ -2,5 +2,11 @@
   "env": {
     "node": true,
     "mocha": true
-  }
+  },
+  "rules": {
+      "import/no-extraneous-dependencies": [
+        "error",
+        { "devDependencies": true }
+      ]
+    }
 }


### PR DESCRIPTION
Moves packages only used in unit tests into `devDependencies`.

Disables - only for unit tests - the `import/no-extraneous-dependencies` error generated by eslint, meaning the api service no longer falls foul of #55. 