### PR TITLE
Return object to Stepper component in topup/amount

### DIFF
--- a/web/src/topup/amount.js
+++ b/web/src/topup/amount.js
@@ -27,7 +27,7 @@ const Amount = ({ params: { storeId }, balance }) => {
                     onDecrement={(amount) => amount}
                     formatDescription={(amount) => `Your balance will be £${currency(balance + amount)}`}
                     formatValue={(amount) => `£${currency(amount)}`}
-                    formatButton={(amount) => 'Top Up using a Card'}
+                    formatButton={(amount) => ({ text: 'Top Up using a Card', disabled: false })}
                     initialValue={500}
                     onClick={(amount) => { hashHistory.push(`/${storeId}/topup/${amount}`); }}
                 />


### PR DESCRIPTION
Forgot to update the `formatButton` function on the 'topup amount' page  to return an object of the form `{ text: 'Button text', disabled: false }` in #146 . 

Forgetting to do this resulted in there being no text for the button to display, therefore the element had a height of 0.