### PR TITLE
factor out stripeDetailsValid

### DIFF
--- a/topup/src/index.ts
+++ b/topup/src/index.ts
@@ -169,11 +169,14 @@ const createStripeCharge = async ({ topupAccount, amount }: { topupAccount: Topu
     }
 };
 
+const stripeDetailsValid = (topupAccount: TopupAccount) => {
+    return topupAccount.stripe
+        && topupAccount.stripe.customer
+        && topupAccount.stripe.nextChargeToken;
+};
+
 const topupExistingAccount = async ({ key, topupAccount, amount }: { key: Key, topupAccount: TopupAccount, amount: number }) => {
-    if (!topupAccount.stripe
-    || !topupAccount.stripe.customer
-    || !topupAccount.stripe.nextChargeToken)
-    {
+    if (!stripeDetailsValid(topupAccount)) {
         throw new Error(`No stripe details registered for ${topupAccount.test ? 'test ' : ''}account ${topupAccount.accountId} - please provide stripeToken`);
     }
 
@@ -196,7 +199,7 @@ const topupExistingAccount = async ({ key, topupAccount, amount }: { key: Key, t
 };
 
 const recordCustomerDetails = async ({ customer, topupAccount }): Promise<TopupAccount> => {
-    if (topupAccount.stripe) {
+    if (stripeDetailsValid(topupAccount)) {
         throw new Error(`Already have stripe details for '${topupAccount.accountId}'`);
     }
 
@@ -229,7 +232,7 @@ const attemptTopup = async ({ key, accountId, userId, amount, stripeToken }: Top
     let topupAccount = await getOrCreate({ accountId, userId });
 
     if (stripeToken) {
-        if (topupAccount.stripe){
+        if (stripeDetailsValid(topupAccount)) {
             throw new Error(`Already have stripe details for '${accountId}'`);
         }
 


### PR DESCRIPTION
this is because we unconditionally store `account.stripe || {}` in
the topup account table.

This means we get an object back when we read the topup account and
need to be more stringent when deciding whether we already have
topup data for a user.