### PR TITLE
tokens now expire at the right time

### DIFF
--- a/transaction/package.json
+++ b/transaction/package.json
@@ -14,7 +14,6 @@
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "http-status": "^0.2.5",
-    "ms": "^0.7.2",
     "node-fetch": "^1.6.3",
     "uuid": "^3.0.1",
     "validator": "^6.2.0",
@@ -22,7 +21,6 @@
   },
   "devDependencies": {
     "@types/express": "^4.0.34",
-    "@types/ms": "^0.7.29",
     "@types/node": "0.0.2",
     "@types/node-fetch": "^1.6.7",
     "@types/uuid": "^2.0.29",

--- a/user/src/token.ts
+++ b/user/src/token.ts
@@ -5,9 +5,9 @@ const secret = process.env.JWT_SECRET;
 
 const signToken = (payload, expiresIn) => jwt.sign(payload, secret, { algorithm: 'HS256', expiresIn });
 
-export const signAccessToken = ({ userId }) => signToken({ userId }, ms('5m'));
+export const signAccessToken = ({ userId }) => signToken({ userId }, '5m');
 
-export const signRefreshToken = ({ userId, refreshToken }) => signToken({ userId, refreshToken }, ms('1y'));
+export const signRefreshToken = ({ userId, refreshToken }) => signToken({ userId, refreshToken }, '1y');
 
 const verifyToken = (token) => jwt.verify(token, secret, { algorithms: ['HS256'], clockTolerance: ms('30s') });
 


### PR DESCRIPTION
jsonwebtoken expects to deal in seconds OR take `ms` strings.
Also removed extraneous dependencies on `ms`.

#200