### PR TITLE
Wait for session request to complete before loading images

### DIFF
--- a/web/src/item/success.js
+++ b/web/src/item/success.js
@@ -3,19 +3,21 @@ import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
 import { Success } from '../chrome/modal';
 
-export const ItemPurchaseSuccess = ({ item: { name, image } }) =>
+export const ItemPurchaseSuccess = ({ item: { name, image }, loading }) =>
   <Success title={`Enjoy your ${name}!`}
     subtitle="Thank you for your honesty!"
-    image={require(`../item/assets/${image}`)}
-    onClick={() => browserHistory.replace(`/history`)} />;
+    image={loading ? "" : require(`../item/assets/${image}`)}
+    onClick={() => browserHistory.replace(`/history`)}
+    loading={loading} />;
 
 const mapStateToProps = (
-  { store: { items = []} },
+  { store: { items = []}, pending },
   { params: { itemId } }
 ) => {
   const item = items.find(item => item.id === itemId);
   return {
-    item: item || {}
+    item: item || {},
+    loading: pending.length > 0
   };
 };
 

--- a/web/src/register/success.js
+++ b/web/src/register/success.js
@@ -3,19 +3,22 @@ import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
 import { Success } from '../chrome/modal';
 
-export const RegisterSuccess = ({ item: { name, image } }) =>
+export const RegisterSuccess = ({ item: { name, image }, loading }) =>
   <Success title={`Enjoy your ${name}!`}
     subtitle="Thank you for signing up!"
-    image={require(`../item/assets/${image}`)}
-    onClick={() => browserHistory.replace(`/history`)} />;
+    image={loading ? "" : require(`../item/assets/${image}`)}
+    onClick={() => browserHistory.replace(`/history`)}
+    loading={loading}
+    />;
 
 const mapStateToProps = (
-  { store: { items = []} },
+  { store: { items = []}, pending },
   { params: { itemId } }
 ) => {
   const item = items.find(item => item.id === itemId);
   return {
-    item: item || {}
+    item: item || {},
+    loading: pending.length > 0
   };
 };
 


### PR DESCRIPTION
When navigating directly to a page that showed an item image due to a successful purchase, we'd get an error due to the `session` request not having completed. We need this to get the mapping between an itemId and its associated image.

Now, we show 'loading' until the session request has completed.

Note that this fixes the case where a `refreshToken` exists in `localStorage`. However, we still have an issue when the user tries to access these pages without signing in / registering.

Closes #297