### PR TITLE
Remove highlight from nav bar

### DIFF
--- a/web/src/chrome/nav-bar.css
+++ b/web/src/chrome/nav-bar.css
@@ -13,6 +13,7 @@
   margin: auto 0;
   flex: 1;
   text-align: center;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .chrome-nav-bar-icon-store,


### PR DESCRIPTION
This fixes a small, but quite noticeable difference in our web app as opposed to native iOS applications. Please see gifs below...

Before:
![tab highlight on](https://cloud.githubusercontent.com/assets/396605/22698238/ee95c030-ed4b-11e6-9204-fa5124c5b3a6.gif)

After:
![tab highlight off](https://cloud.githubusercontent.com/assets/396605/22698248/f3dfad94-ed4b-11e6-8c03-f4effb058c13.gif)

This CSS property is still enabled on other elements (inputs, other anchor tags that aren't in the nav bar, e.t.c). See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color) for more info on this non-standard (APPLE!!!!) property.