### PR TITLE
api handles a registered user without card details

### DIFF
--- a/api/src/services/session.ts
+++ b/api/src/services/session.ts
@@ -25,7 +25,7 @@ const getUserSessionData = async (key, user) => {
   const allTransactions = accountID ? await getTransactionHistory({ key, accountID }) : [];
   const recentTransactions = allTransactions.slice(0, 10);
 
-  let cardDetails;
+  let cardDetails = null;
   if (userRegistered(user)) {
     try {
       cardDetails = await getCardDetails(key, id);
@@ -35,12 +35,7 @@ const getUserSessionData = async (key, user) => {
       }
 
       /* User is registered but has no card details - this means they managed
-       * to sign up but weren't successful in their initial topup.
-       *
-       * Returning undefined cardDetails will push the frontend/web into
-       * retrying the topup.
-       */
-      cardDetails = undefined;
+       * to sign up but weren't successful in their initial topup. */
     }
   }
 


### PR DESCRIPTION
Previously api would allow an exception to propagate to the frontend
UI, meaning if a user registered but their card topup didn't work,
they'd be permanently stuck on an error screen.

Now if they successfully register (but fail to topup) they can still
browse the store and more importantly, submit support questions.

The topup page will still fail / raise an error locally in the UI,
but this is fixed by another commit.