### PR TITLE
Fix top up icon being a 'misc-bar'

### DIFF
--- a/web/src/history/item.js
+++ b/web/src/history/item.js
@@ -70,6 +70,9 @@ const mapStateToProps = (
     default:
       return {
         isTopUp: false,
+        timestamp,
+        text: 'Unknown',
+        amount
       };
   }
 };


### PR DESCRIPTION
Silly me - we want to look up the item image at the point of assigning the image prop, otherwise we end up performing a 'safe lookup' of the top up asset which fails, resulting in the misc-bar being displayed.