### PR TITLE
punt users out to / if they don't have a refreshToken

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -48,13 +48,22 @@ const store = createStore(
 
 store.dispatch(performInitialise({}));
 
+
+const redirectUnauthorised = (nextState, replace) => {
+  const { refreshToken } = store.getState();
+
+  if (!refreshToken){
+    replace('/');
+  }
+};
+
 ReactDOM.render((
   <Provider store={store}>
     <Router history={history} onUpdate={() => scrollTo(0, 0)}>
       <Route path="/" component={Home} />
       <Route path="/success" component={HomeSuccess} />
       <Route path="/error" component={Error} />
-      <Route path="/" component={({ children }) => children}>
+      <Route path="/" component={({ children }) => children} onEnter={redirectUnauthorised}>
         <Route path="register" component={RegisterEmail} />
         <Route path="register/:itemId" component={RegisterEmail} />
         <Route path="register//success" component={RegisterSuccessWithoutPurchase} />
@@ -77,13 +86,13 @@ ReactDOM.render((
         <Route path="profile/logout" component={LogoutProfile} />
         <Route path="help" component={Help} />
         <Route path="help/success" component={HelpSuccess} />
-        <Route path=":storeCode"
-          onEnter={(nextState, replace) => {
-            const { params: { storeCode }, location: { query: { code: emailToken } } } = nextState;
-            store.dispatch(performInitialise({ storeCode, emailToken }));
-            replace('/store');
-          } } />
       </Route>
+      <Route path="/:storeCode"
+        onEnter={(nextState, replace) => {
+          const { params: { storeCode }, location: { query: { code: emailToken } } } = nextState;
+          store.dispatch(performInitialise({ storeCode, emailToken }));
+          replace('/store');
+        } } />
     </Router>
   </Provider>
 ), document.getElementById('root'));


### PR DESCRIPTION
One way to reproduce the bug this fixes:
- Open the app as a fresh/clean user
- Enter (and submit) an email known to the system in the signup page
- After reciving the 'magic email link sent' prompt, go back (via the browser) to the email entry page
- Enter (and submit) an email unknown to the system
- Observe infinite loading / a 500 in the network response

Other, simpler ways to reproduce this are things like navigating to `/purchase/<itemid>` and so on without having a refresh token.

When testing we need to be sure to check all routes, particularly the magic-link login