### PR TITLE
conditionalise retiring and deleting services

### DIFF
--- a/aws/src/ecs/service.ts
+++ b/aws/src/ecs/service.ts
@@ -91,21 +91,23 @@ export const pruneServices = async ({ cluster, filter = (_: { name }) => false }
 
   winston.debug('service: serviceArnsToPrune', serviceArnsToPrune);
 
-  const updatePromises = serviceArnsToPrune.map(service =>
-    ecs.updateService({ cluster, service, desiredCount: 0 })
-      .promise()
-  );
+  if (serviceArnsToPrune.length > 0) {
+    const updatePromises = serviceArnsToPrune.map(service =>
+      ecs.updateService({ cluster, service, desiredCount: 0 })
+        .promise()
+    );
 
-  await Promise.all(updatePromises);
+    await Promise.all(updatePromises);
 
-  await waitForServicesStable({ cluster, services: serviceArnsToPrune });
+    await waitForServicesStable({ cluster, services: serviceArnsToPrune });
 
-  winston.debug('service: services stable', listResponse);
+    winston.debug('service: services stable', listResponse);
 
-  const deletePromises = serviceArnsToPrune.map(service =>
-    ecs.deleteService({ cluster, service })
-      .promise()
-  );
+    const deletePromises = serviceArnsToPrune.map(service =>
+      ecs.deleteService({ cluster, service })
+        .promise()
+    );
 
-  await Promise.all(deletePromises);
+    await Promise.all(deletePromises);
+  }
 };


### PR DESCRIPTION
if we had zero servies to retire/delete, we'd get something like:

2017-02-20T16:39:50.939Z DEBUG service: serviceArnsToPrune {}
{ Error: TypeError: length() expected argument 1 to be type 2,3,4 but received type 7 instead.
    at Object.Runtime._validateArgs (/home/ubuntu/honesty-store/aws/node_modules/jmespath/jmespath.js:1252:23)
    at Object.Runtime.callFunction (/home/ubuntu/honesty-store/aws/node_modules/jmespath/jmespath.js:1214:12)
    at Object.TreeInterpreter.visit (/home/ubuntu/honesty-store/aws/node_modules/jmespath/jmespath.js:1068:35)
    at Object.TreeInterpreter.visit (/home/ubuntu/honesty-store/aws/node_modules/jmespath/jmespath.js:978:28)
    at Object.TreeInterpreter.search (/home/ubuntu/honesty-store/aws/node_modules/jmespath/jmespath.js:862:23)
    at Object.search (/home/ubuntu/honesty-store/aws/node_modules/jmespath/jmespath.js:1660:26)
    at AWS.ResourceWaiter.inherit.matchers.path (/home/ubuntu/honesty-store/aws/node_modules/aws-sdk/lib/resource_waiter.js:75:29)
    at /home/ubuntu/honesty-store/aws/node_modules/aws-sdk/lib/resource_waiter.js:32:22
    at Array.forEach (native)
    at Request.CHECK_ACCEPTORS (/home/ubuntu/honesty-store/aws/node_modules/aws-sdk/lib/resource_waiter.js:29:13)
  message: 'TypeError: length() expected argument 1 to be type 2,3,4 but received type 7 instead.',
  code: 'Error',
  time: 2017-02-20T16:39:51.265Z,
  statusCode: 400,
  retryable: false,
  retryDelay: 3.6283595203992602 }