### PR TITLE
Fix initialise typo and future store-code bug

### DIFF
--- a/web/src/actions/inititialise.js
+++ b/web/src/actions/inititialise.js
@@ -3,11 +3,11 @@ import { performSession } from './session';
 import { performSignin2 } from './signin2';
 import history from '../history';
 
-export const INTIALISE = 'INTIALISE';
+export const INITIALISE = 'INITIALISE';
 
 const initialise = () => {
   return {
-    type: INTIALISE
+    type: INITIALISE
   };
 };
 


### PR DESCRIPTION
This bug came to light in the routeless error screen branch - the
state would never get `initialised` set to true, so we'd reinitialise
every time and get stuck on the invalid-store-code error.

bug ported to live