### PR TITLE
Use unicode/html entities for pound sterling symbol

### DIFF
--- a/web/src/format/Currency.js
+++ b/web/src/format/Currency.js
@@ -13,10 +13,9 @@ const formatAny = (value) => {
 
 const Currency = ({ amount }) => {
   const showPence = Math.abs(amount) < 100;
-
   return (
     <span>
-      {showPence || <small>£</small>}
+      {showPence || <small>&#163;</small>}
       {showPence ? amount : formatAny(amount)}
       {showPence && <small>p</small>}
     </span>

--- a/web/src/register/card.js
+++ b/web/src/register/card.js
@@ -67,7 +67,8 @@ class Card extends React.Component {
   }
 
   getConfirmButtonText() {
-    const topUpText = 'Confirm £5 Top Up';
+    const sterlingSymbol = '\u00A3';
+    const topUpText = `Confirm ${sterlingSymbol}5 Top Up`;
     const { itemId } = this.props;
     return itemId ? `${topUpText} & Pay` : topUpText;
   }
@@ -96,7 +97,7 @@ class Card extends React.Component {
             </div>
             :
             <div>
-              <p>Please enter the details of the card you want us to collect your first £5 top up from</p>
+              <p>Please enter the details of the card you want us to collect your first &#163;5 top up from</p>
               <p>Don't worry, your balance won't expire, we'll never perform a top up without your
                         permission and you can close your account at any time</p>
             </div>


### PR DESCRIPTION
Fixes a few issues in the iOS app:

![fullsizerender](https://cloud.githubusercontent.com/assets/396605/23160060/f61869b2-f81c-11e6-8e9d-ccaec3c1ae17.jpg)
