### PR TITLE
/signin/success doesn't boot out tokenless users

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -70,7 +70,7 @@ ReactDOM.render((
         <Route path="register/:itemId/partial" component={RegisterPartialSuccess} onEnter={redirectUnauthorised} />
         <Route path="register//:emailAddress" component={RegisterCard} onEnter={redirectUnauthorised} />
         <Route path="register/:itemId/:emailAddress" component={RegisterCard} onEnter={redirectUnauthorised} />
-        <Route path="signin/success" component={SignInSuccess} onEnter={redirectUnauthorised} />
+        <Route path="signin/success" component={SignInSuccess} />
         <Route path="store" component={Store} onEnter={redirectUnauthorised} />
         <Route path="item/:itemId" component={ItemDetail} onEnter={redirectUnauthorised} />
         <Route path="item/:itemId/success" component={ItemPurchaseSuccess} onEnter={redirectUnauthorised} />


### PR DESCRIPTION
... as we clear their tokens on successful signin, so still want the
page to display. All other routes where we've cleared their tokens are
already "/" (e.g. logout).