### PR TITLE
Save topupAccount.created in dynamo

### DIFF
--- a/topup/src/index.ts
+++ b/topup/src/index.ts
@@ -89,11 +89,12 @@ const update = async ({ topupAccount }: { topupAccount: TopupAccount }) => {
         id: topupAccount.id
       },
       UpdateExpression:
-      'set stripe = :stripe, accountId = :accountId, userId = :userId',
+      'set stripe = :stripe, accountId = :accountId, userId = :userId, created = :created',
       ExpressionAttributeValues: {
         ':stripe': topupAccount.stripe || {},
         ':accountId': topupAccount.accountId,
-        ':userId': topupAccount.userId
+        ':userId': topupAccount.userId,
+        ':created': topupAccount.created
       }
     })
     .promise();


### PR DESCRIPTION
I stupidly forgot this bit - unlike Transaction Accounts, for Topup Accounts we don't `.put` the entire object, we just `.update`