### PR TITLE
Revert "Use unicode/html entities for pound sterling symbol"

### DIFF
--- a/web/src/format/Currency.js
+++ b/web/src/format/Currency.js
@@ -13,9 +13,10 @@ const formatAny = (value) => {
 
 const Currency = ({ amount }) => {
   const showPence = Math.abs(amount) < 100;
+
   return (
     <span>
-      {showPence || <small>&#163;</small>}
+      {showPence || <small>£</small>}
       {showPence ? amount : formatAny(amount)}
       {showPence && <small>p</small>}
     </span>

--- a/web/src/register/card.js
+++ b/web/src/register/card.js
@@ -81,8 +81,7 @@ class Card extends React.Component {
   }
 
   getConfirmButtonText() {
-    const sterlingSymbol = '\u00A3';
-    const topUpText = `Confirm ${sterlingSymbol}5 Top Up`;
+    const topUpText = 'Confirm £5 Top Up';
     const { itemId } = this.props;
     return itemId ? `${topUpText} & Pay` : topUpText;
   }
@@ -111,7 +110,7 @@ class Card extends React.Component {
             </div>
             :
             <div>
-              <p>Please enter the details of the card you want us to collect your first &#163;5 top up from</p>
+              <p>Please enter the details of the card you want us to collect your first £5 top up from</p>
               <p>Don't worry, your balance won't expire, we'll never perform a top up without your
                         permission and you can close your account at any time</p>
             </div>


### PR DESCRIPTION
The commit being reverted didn't actually solve the problem. Instead, the iOS app required the addition of the charset meta tag.