### PR TITLE
Handle an invalid refreshToken properly

### DIFF
--- a/web/src/actions/session.js
+++ b/web/src/actions/session.js
@@ -1,8 +1,9 @@
 import apifetch from './apirequest';
+import history from '../history';
 
 export const SESSION_REQUEST = 'SESSION_REQUEST';
 export const SESSION_SUCCESS = 'SESSION_SUCCESS';
-export const SESSION_UNAUTHORISED = 'SESSION_UNAUTHORISED';
+export const SESSION_RESET = 'SESSION_RESET';
 export const SESSION_FAILURE = 'SESSION_FAILURE';
 
 const sessionRequest = () => {
@@ -25,9 +26,10 @@ const sessionFailure = (error) => {
   };
 };
 
-const sessionUnauthorised = () => {
+const sessionReset = (error) => {
   return {
-    type: SESSION_UNAUTHORISED
+    type: SESSION_RESET,
+    error
   };
 };
 
@@ -43,8 +45,11 @@ export const performSession = () => async (dispatch, getState) => {
     dispatch(sessionSuccess(response));
 
   } catch (e) {
-    if (e.code === 'ResponseError' && e.status === 401) {
-      dispatch(sessionUnauthorised());
+    if (e.code === 'TokenError') {
+      // Our refresh token hasn't expired (that's RefreshTokenExpired),
+      // it's just totally mangled (for example, a non-live token used on live).
+
+      dispatch(sessionReset(e));
       history.push(`/`);
       return;
     }

--- a/web/src/error/errors.js
+++ b/web/src/error/errors.js
@@ -18,7 +18,7 @@ export const errorDefinitions = {
   CardExpired: { message: 'Card expired', retryable: true },
   CardDeclined: { message: 'Card declined', retryable: true },
   CardError: { message: 'Hit a problem with your card details', retryable: true },
-  TokenError: { message: 'Invalid token', retryable: false },
+  TokenError: { message: 'Your local session is corrupt - please sign in', retryable: true },
   AccessTokenExpired: { message: 'Your access has expired - please sign in', retryable: false },
   RefreshTokenExpired: { message: 'Your session has expired - please sign in', retryable: false },
   MagicLinkTokenExpired: { message: 'Your magic link token has expired, please try again', retryable: false },

--- a/web/src/reducers/reducer.js
+++ b/web/src/reducers/reducer.js
@@ -2,7 +2,7 @@ import { DISMISS_ERROR } from '../actions/dismissError';
 import { INITIALISE } from '../actions/inititialise';
 import { REGISTER_REQUEST, REGISTER_SUCESSS, REGISTER_FAILURE } from '../actions/register';
 import { REGISTER2_REQUEST, REGISTER2_SUCESSS, REGISTER2_FAILURE } from '../actions/register2';
-import { SESSION_REQUEST, SESSION_SUCCESS, SESSION_UNAUTHORISED, SESSION_FAILURE } from '../actions/session';
+import { SESSION_REQUEST, SESSION_SUCCESS, SESSION_RESET, SESSION_FAILURE } from '../actions/session';
 import { TOPUP_REQUEST, TOPUP_SUCCESS, TOPUP_FAILURE } from '../actions/topup';
 import { PURCHASE_REQUEST, PURCHASE_SUCCESS, PURCHASE_FAILURE } from '../actions/purchase';
 import { LOGOUT_REQUEST, LOGOUT_SUCCESS, LOGOUT_FAILURE } from '../actions/logout';
@@ -165,12 +165,12 @@ export default (state = getInitialState(), action) => {
         pending: state.pending.filter(e => e !== 'session')
       };
     }
-    case SESSION_UNAUTHORISED: {
+    case SESSION_RESET: {
       const error = save({ refreshToken: undefined });
 
       return {
         ...getInitialState(),
-        error
+        error: action.error || error
       };
     }
     case SESSION_FAILURE: {


### PR DESCRIPTION
Closes #383 

We no longer get stuck in an infinite loop as we properly detect the right error string, and so (eventually) dismiss the error.

To test, alter your local storage so it's something like `refreshToken = "abc"`, then navigate to `/store` (or anywhere where we'll perform a session request).