### PR TITLE
No longer go back when dismissing error

### DIFF
--- a/web/src/actions/dismissError.js
+++ b/web/src/actions/dismissError.js
@@ -1,5 +1,3 @@
-import history from '../history';
-
 export const DISMISS_ERROR = 'DISMISS_ERROR';
 
 const dismiss = () => {
@@ -10,5 +8,4 @@ const dismiss = () => {
 
 export const dismissError = () => async (dispatch) => {
   dispatch(dismiss());
-  history.goBack();
 };


### PR DESCRIPTION
This is a bit of a stop gap until #340 is completed.

I've been through all the errors and don't think there are any issues with simply hiding the error on dismiss now we handle invalid `refreshToken`'s a lot more gracefully thanks to #390.