### PR TITLE
add new box to ncl store

### DIFF
--- a/api/src/services/store.ts
+++ b/api/src/services/store.ts
@@ -10,7 +10,8 @@ const ncl = {
     'af02cf9f-d8b7-4d7e-a701-3addb212a7ba',
     '680a2849-4a37-47f0-88a6-b9b1df91d5f4',
     '340e5dba-309d-4f7d-b20d-f1f778883627',
-    '67bd2798-87d0-4208-9845-4f35da29f144'
+    '67bd2798-87d0-4208-9845-4f35da29f144',
+    'f6cbf4c2-ead1-430a-afa6-dcf1d10f3e66'
   ],
   itemPrices: {
     '46ced0c0-8815-4ed2-bfb6-40537f5bd512': 50,


### PR DESCRIPTION

Closes #430 

box contains:
- 11 quavers
- 11 wotsits
- 21 kitkats
- 10 skittles
- 5 salt & vinegar walkers

the following JSON must be added to `honesty-store-box` on merge to live:

```
  {
    id: 'f6cbf4c2-ead1-430a-afa6-dcf1d10f3e66',
    items: [
      { itemId: '3b7a6669-770c-4dbb-97e2-0e0aae3ca5ff', count: 22 }, // 11 quavers + 11 wotsits
      { itemId: '3fa0db7c-3f90-404e-b875-3792eda3e185', count: 21 }, // kitkat
      { itemId: '78816fba-150d-4282-b43d-900df45cea8b', count: 10 }, // skittles
      { itemId: '28b0a802-bef3-478b-81d0-034e3ac02092', count: 5 }, // s&v
    ],
    packed: '20170302',
    shipped: '20170302',
    recieved: '20170302'
  }
```
