### PR TITLE
Fix key logging / wrangling

### DIFF
--- a/service/src/router.ts
+++ b/service/src/router.ts
@@ -63,7 +63,7 @@ const createEndPoint = (service, internalRouter, version, method: 'get' | 'post'
       authentication,
       (request, response) => {
         const timer = time();
-        const key = extractKey(request, service);
+        const key = request.key || extractKey(request, service);
         // tslint:disable-next-line:max-line-length
         const { params, body } = request;
         info(key, `handling ${method} ${request.url}`, { params, body });


### PR DESCRIPTION
Previously we would ignore `request.key` on a service route, instead attempting to either extract an existing key (which worked fine for sub-services) or create one (which is what the api service was doing).

The problem is that api service would have authenticated users and the `request` object would already have a key on it, which we were ignoring. We now always attempt to use this key (on which there is additional information) before attempting to extract a key from the request headers or create a service key.

To test: login with a new user, get your user id, check your user id appears in cloudwatch under the logged out `tags` object.