### PR TITLE
Add VAT rate to batches and fix my inability to read invoices

### DIFF
--- a/box/src/batch.ts
+++ b/box/src/batch.ts
@@ -213,7 +213,7 @@ const batchesInternal: Batch[] = [
     itemId: '8fd928e0-06c9-4958-9259-719dc451a8c2',
     itemQuantity: 24,
     expiry: null,
-    priceExcludingTax: 622,
+    priceExcludingTax: 777,
     VATRate: 0.2
   },
   {


### PR DESCRIPTION
I'm incapable of reading an invoice, so fixed to be inline with the [spreadsheet](https://docs.google.com/spreadsheets/d/1i5Xufman-WGvi2WrYS9dfzxV4_vHMnEViWx7ws9oGbg/edit#gid=1436712140). Fortunately, these batches aren't used yet, however #423 will begin to make use of them.

Additionally, we no longer include the price inc VAT as we can easily derive this from the `priceExcludingVAT * (1 + VATRate)`.