### PR TITLE
Fix undefined TokenError

### DIFF
--- a/web/src/actions/dismissError.js
+++ b/web/src/actions/dismissError.js
@@ -1,4 +1,4 @@
-import { errorDefinitions } from '../error/errors';
+import getErrorDefinition from '../error/errors';
 import history from '../history';
 
 export const DISMISS_ERROR = 'DISMISS_ERROR';
@@ -12,7 +12,7 @@ const dismiss = () => {
 export const dismissError = (code) => async (dispatch) => {
 
   if (code != null) {
-    const { redirectionURL } = errorDefinitions[code];
+    const { redirectionURL } = getErrorDefinition(code);
     if (redirectionURL != null) {
       history.push(redirectionURL);
     }

--- a/web/src/error/errors.js
+++ b/web/src/error/errors.js
@@ -5,7 +5,7 @@ const dismissalText = {
   DISMISS: `Tap to dismiss`
 };
 
-export const errorDefinitions = {
+const errorDefinitions = {
   TopupExceedsMaxBalance: {
     message: `Topping up would exceed your maximum balance`,
     dismissalText: dismissalText.DISMISS
@@ -83,4 +83,8 @@ export const errorDefinitions = {
   CardInvalidExpiryYear: { message: `Invalid expiry year` },
   CardIncorrectCVC: { message: `Incorrect CVC` },
   CardInvalidCVC: { message: `Invalid CVC` },
+};
+
+export default (code) => {
+  return errorDefinitions[code] || errorDefinitions['UnknownError'];
 };

--- a/web/src/error/index.js
+++ b/web/src/error/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { dismissError } from '../actions/dismissError';
-import { errorDefinitions } from './errors';
+import getErrorDefinition from './errors';
 import Alert from '../layout/alert';
 import Error from '../item/error.js';
 import './index.css';
@@ -26,10 +26,7 @@ const mapStateToProps = ({ error: { fullPage: error } }) => {
     return {};
   }
 
-  let errorDef = errorDefinitions[error.code];
-  if (!errorDef) {
-    errorDef = errorDefinitions['UnknownError'];
-  }
+  let errorDef = getErrorDefinition(error.code);
 
   const { message, actionDescription, dismissalText } = errorDef;
 

--- a/web/src/register/card.js
+++ b/web/src/register/card.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
-import { errorDefinitions } from '../error/errors';
+import getErrorDefinition from '../error/errors';
 import { Back } from '../chrome/link';
 import { performRegister2 } from '../actions/register2';
 import Full from '../layout/full';
@@ -93,7 +93,7 @@ class Card extends React.Component {
                 <p>
                 {
                   error.code
-                  ? errorDefinitions[error.code].message
+                  ? getErrorDefinition(error.code).message
                   : error.message
                 }
                 </p>


### PR DESCRIPTION
A small issue of my own creation: when refactoring the error definitions in 801fc17f I managed to delete the definition for `TokenError`.

Fortunately this is only displayed when the `refreshToken` is invalid due to either us using a stale token from another branch or the user's been mucking about with their local storage (unlikely to happen!).

The main issue caused by this was a nasty type error being emitted in the console due to the `dismissError` action creator not handling an undefined error definition. We now add a bit of a failsafe by requiring all access to go via a function which will always return a valid definition (a generic `UnknownError` if we can't find a definition for the given code).