### PR TITLE
add version to transaction, and lock on it

### DIFF
--- a/transaction/src/client/index.ts
+++ b/transaction/src/client/index.ts
@@ -20,6 +20,7 @@ export interface Account {
   id: string;
   created: number;
   balance: number;
+  version: number;
   transactions: Transaction[];
 }
 


### PR DESCRIPTION
Step 1 of N for migrating the transaction database to the new format

- [X] test on https://transaction-lock.honesty.store/
- [X] migrate live's transaction [database](https://eu-west-1.console.aws.amazon.com/dynamodb/home?region=eu-west-1#tables:selected=honesty-store-transaction) to include versions