### PR TITLE
Make weight an optional property on Item

### DIFF
--- a/api/src/services/item.ts
+++ b/api/src/services/item.ts
@@ -7,7 +7,7 @@ interface Item {
   unitPlural: string;
   location?: string;
   image: string;
-  weight: number;
+  weight?: number;
   notes?: string;
 }
 

--- a/web/src/item/detail.js
+++ b/web/src/item/detail.js
@@ -99,10 +99,13 @@ const ItemDetail = ({
                   <td>{location}</td>
                 </tr>
               }
-              <tr>
-                  <th className="col-6 right-align">Weight</th>
-                  <td>{`${weight}g`}</td>
-              </tr>
+              {
+                weight &&
+                <tr>
+                    <th className="col-6 right-align">Weight</th>
+                    <td>{`${weight}g`}</td>
+                </tr>
+              }
             </tbody>
           </table>
           <h3>Price Breakdown</h3>


### PR DESCRIPTION
When users send us marketplace items, they won't necessarily send us the weight. We need to decide whether this is important - if not, then we can make it optional and hide it.

An alternative would be to explicitly require the weight as an input field when users are submitting marketplace items.