### PR TITLE
Fix baseurl

### DIFF
--- a/aws/src/script/deploy.ts
+++ b/aws/src/script/deploy.ts
@@ -38,22 +38,6 @@ const serviceConfig = {
   },
   api: {
     loadBalancer: { pathPattern: '/api/*', priority: 1 }
-  },
-  transaction: {
-    database: true,
-    loadBalancer: { pathPattern: '/transaction/*', priority: 3 }
-  },
-  user: {
-    database: true,
-    loadBalancer: { pathPattern: '/user/*', priority: 4 }
-  },
-  topup: {
-    database: true,
-    loadBalancer: { pathPattern: '/topup/*', priority: 5 }
-  },
-  survey: {
-    database: true,
-    loadBalancer: { pathPattern: '/survey/*', priority: 6 }
   }
 };
 const lambdaConfig = {


### PR DESCRIPTION
This migrates everything onto lambdas programatically. `baseUrl` is now unused, except for DNS. This will eventually be merged with `lambdaBaseUrl` as part of #619 