### PR TITLE
transaction service only emits ratified transactions

### DIFF
--- a/transaction/src/client/stream.ts
+++ b/transaction/src/client/stream.ts
@@ -4,16 +4,12 @@ import { InternalAccount, Transaction } from './';
 const isAccount = (account: any): account is InternalAccount =>
   account.balance != null;
 
-const hasNewTransaction = ({ transactionHead: oldTxHead }: InternalAccount, { transactionHead: newTxHead }: InternalAccount) =>
-  oldTxHead !== newTxHead;
-
 export const subscribeTransactions = function* (event): IterableIterator<Transaction> {
   for (const record of event.Records) {
-    const oldImage = DynamoDB.Converter.output({ M: record.dynamodb.OldImage });
-    const newImage = DynamoDB.Converter.output({ M: record.dynamodb.NewImage });
+    const image = DynamoDB.Converter.output({ M: record.dynamodb.NewImage });
 
-    if (isAccount(oldImage) && isAccount(newImage) && hasNewTransaction(oldImage, newImage)) {
-      yield newImage.cachedTransactions[0];
+    if (isAccount(image)) {
+      yield image.cachedTransactions[0]; // may generate spurious transactions, but reducers will handle this
     }
   }
 };


### PR DESCRIPTION
The main ways I could think of doing this were:

- Hold onto transactions, look for the account update, then emit the
  transactions that came before it.  Problem being that these events
  may be spread across batch boundaries, so we can't remember the
  transactions.

- Always emit `.cachedTransactions[0]` when we get an update to an
  account. Simple, but we may emit a transaction multiple times, the
  first being when it's added, and subsequently when we've just changed
  something else about the account aggregate.
  This is fine, as it's handled by the reducer. A possible solution
  would be to have a 'lastChanged' field on account, and we toggle it
  between `'cachedTransactions'` and `'other'`. Thus we only need to
  emit a transaction when `account.lastChanged` is
  `'cachedTransactions'`. Seemed a bit too complicated for now.
  Note that this approach assumes that consecutive changes to the same
  aggregate are given to us as individual events, rather than being
  coalesced into one. I did a bit of googling and am pretty sure this is
  the case.