### PR TITLE
change dynamo trigger to TRIM_HORIZON - don't drop records post-deploy

### DIFF
--- a/aws/src/lambda/function.ts
+++ b/aws/src/lambda/function.ts
@@ -144,7 +144,7 @@ export const ensureFunctionDynamoTrigger = async (
     return await lambda.createEventSourceMapping({
       EventSourceArn: source,
       FunctionName: lambdaFunc.FunctionArn,
-      StartingPosition: 'LATEST'
+      StartingPosition: 'TRIM_HORIZON'
     })
       .promise();
   } catch (e) {


### PR DESCRIPTION
Turns out there's no way to even get at the `TRIM_HORIZON` setting, never mind modify it, so we can't even diff the event sources to potentially replace a `LATEST` with `TRIM_HORIZON`.

My plan is to have this approved, then just before the build, I'll delete the event sources on live. This deployment should regenerate them, and `TRIM_HORIZON` means that we'll re-pickup any missing events, provided the build doesn't take > 24 hours.