### PR TITLE
Remove 'generic', 'unit', 'location', 'weight' and 'expiry' references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+lerna-debug.log

--- a/api/src/controllers/marketplace.ts
+++ b/api/src/controllers/marketplace.ts
@@ -8,7 +8,7 @@ export default (router) => {
     async (
       key,
       _params,
-      { item: { description, totalPrice, quantity, location, expiry } },
+      { item: { description, totalPrice, quantity } },
       { user }
     ) => {
       const message = 'Marketplace request';
@@ -29,14 +29,6 @@ export default (router) => {
           {
             title: 'Item-Quantity',
             value: quantity
-          },
-          {
-            title: 'Item-Location',
-            value: location
-          },
-          {
-            title: 'Item-Expiry',
-            value: expiry
           }
         ]
       });

--- a/api/src/services/store.ts
+++ b/api/src/services/store.ts
@@ -4,10 +4,6 @@ export interface StoreItem {
   id: string;
   name: string;
   qualifier?: string;
-  genericName: string;
-  genericNamePlural: string;
-  unit: string;
-  unitPlural: string;
   image: string;
   isMarketplace: boolean;
   count: number;
@@ -15,9 +11,6 @@ export interface StoreItem {
     total: number;
     breakdown: PriceBreakdown;
   };
-  expiry?: number;
-  weight?: number;
-  location?: string;
 }
 
 export interface PriceBreakdown {
@@ -47,10 +40,6 @@ export const storeItems = async (key, storeId): Promise<StoreItem[]> => {
       id: item.id,
       name: item.name,
       qualifier: item.qualifier,
-      genericName: item.genericName,
-      genericNamePlural: item.genericNamePlural,
-      unit: item.unit,
-      unitPlural: item.unitPlural,
       image: item.image,
       isMarketplace: true,
       count: item.availableCount,

--- a/aws/src/table/tables.ts
+++ b/aws/src/table/tables.ts
@@ -445,35 +445,19 @@ const dirToTable = {
         name: 'Nakd',
         qualifier: 'Apple Crunch Bar',
         image: 'nakd-apple-crunch.svg',
-        weight: 30,
-        unit: 'bar',
-        unitPlural: 'bars',
-        genericName: 'cereal bar',
-        genericNamePlural: 'cereal bars',
         version: 0
       },
       {
         id: '46ced0c0-8815-4ed2-bfb6-40537f5bd512',
         name: 'Walkers',
         image: 'walkers-cheese-onion.svg',
-        weight: 32.5,
         qualifier: 'Cheese & Onion',
-        unit: 'pack',
-        unitPlural: 'packs',
-        genericName: 'crisps',
-        genericNamePlural: 'crisps',
         version: 0
       },
       {
         id: 'cf7a7886-c30d-4760-8c15-39adb2dc8649',
         name: 'Diet Coke',
-        location: 'Fridge',
         image: 'diet-cola-can.svg',
-        weight: 400,
-        unit: 'can',
-        unitPlural: 'cans',
-        genericName: 'drink',
-        genericNamePlural: 'drinks',
         version: 0
       },
       {
@@ -481,11 +465,6 @@ const dirToTable = {
         name: 'Nature Valley',
         qualifier: 'Crunchy Oats & Honey',
         image: 'nature-valley-oats-n-honey.svg',
-        weight: 42,
-        unit: 'bar',
-        unitPlural: 'bars',
-        genericName: 'cereal bar',
-        genericNamePlural: 'cereal bars',
         version: 0
       }
     ]
@@ -562,8 +541,6 @@ const dirToTable = {
         items: [
           {
             availableCount: 1000,
-            genericName: 'crisps',
-            genericNamePlural: 'crisps',
             id: '46ced0c0-8815-4ed2-bfb6-40537f5bd512',
             image: 'walkers-cheese-onion.svg',
             listCount: 1000,
@@ -573,14 +550,10 @@ const dirToTable = {
             qualifier: 'Cheese & Onion',
             refundCount: 0,
             sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633',
-            unit: 'pack',
-            unitPlural: 'packs',
             revenue: 0
           },
           {
             availableCount: 1000,
-            genericName: 'cereal bar',
-            genericNamePlural: 'cereal bars',
             id: 'faeda516-bd9f-41ec-b949-7a676312b0ae',
             image: 'nature-valley-oats-n-honey.svg',
             listCount: 1000,
@@ -590,14 +563,10 @@ const dirToTable = {
             qualifier: 'Crunchy Oats & Honey',
             refundCount: 0,
             sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633',
-            unit: 'bar',
-            unitPlural: 'bars',
             revenue: 0
           },
           {
             availableCount: 1000,
-            genericName: 'drink',
-            genericNamePlural: 'drinks',
             id: 'cf7a7886-c30d-4760-8c15-39adb2dc8649',
             image: 'diet-cola-can.svg',
             listCount: 1000,
@@ -606,14 +575,10 @@ const dirToTable = {
             purchaseCount: 0,
             refundCount: 0,
             sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633',
-            unit: 'can',
-            unitPlural: 'cans',
             revenue: 0
           },
           {
             availableCount: 1000,
-            genericName: 'cereal bar',
-            genericNamePlural: 'cereal bars',
             id: '32a9520f-f407-42ee-9bc5-ab9e2a9c76ea',
             image: 'nakd-apple-crunch.svg',
             listCount: 1000,
@@ -623,8 +588,6 @@ const dirToTable = {
             qualifier: 'Apple Crunch Bar',
             refundCount: 0,
             sellerId: 'c50234ff-6c33-4878-a1ab-05f6b3e7b649',
-            unit: 'bar',
-            unitPlural: 'bars',
             revenue: 0
           }
         ],
@@ -633,17 +596,13 @@ const dirToTable = {
           data: {
             id: '0e02a0c9-40fa-4083-98b7-b5e8a183d251',
             listing: {
-              genericName: 'cereal bar',
-              genericNamePlural: 'cereal bars',
               id: '32a9520f-f407-42ee-9bc5-ab9e2a9c76ea',
               image: 'nakd-apple-crunch.svg',
               listCount: 1000,
               name: 'Nakd',
               price: 36,
               qualifier: 'Apple Crunch Bar',
-              sellerId: 'c50234ff-6c33-4878-a1ab-05f6b3e7b649',
-              unit: 'bar',
-              unitPlural: 'bars'
+              sellerId: 'c50234ff-6c33-4878-a1ab-05f6b3e7b649'
             },
             storeId: '1e7c9c0d-a9be-4ab7-8499-e57bf859978d',
             type: 'store-list'
@@ -659,17 +618,13 @@ const dirToTable = {
         data: {
           id: '37919edb-09e4-47ee-8b9e-42be8d01b52a',
           listing: {
-            genericName: 'cereal bar',
-            genericNamePlural: 'cereal bars',
             id: 'faeda516-bd9f-41ec-b949-7a676312b0ae',
             image: 'nature-valley-oats-n-honey.svg',
             listCount: 1000,
             name: 'Nature Valley',
             price: 51,
             qualifier: 'Crunchy Oats & Honey',
-            sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633',
-            unit: 'bar',
-            unitPlural: 'bars'
+            sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633'
           },
           storeId: '1e7c9c0d-a9be-4ab7-8499-e57bf859978d',
           type: 'store-list'
@@ -684,16 +639,12 @@ const dirToTable = {
         data: {
           id: '9c071db4-8417-4131-9b1e-4ce5f07353d3',
           listing: {
-            genericName: 'drink',
-            genericNamePlural: 'drinks',
             id: 'cf7a7886-c30d-4760-8c15-39adb2dc8649',
             image: 'diet-cola-can.svg',
             listCount: 1000,
             name: 'Diet Coke',
             price: 130,
-            sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633',
-            unit: 'can',
-            unitPlural: 'cans'
+            sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633'
           },
           storeId: '1e7c9c0d-a9be-4ab7-8499-e57bf859978d',
           type: 'store-list'
@@ -708,17 +659,13 @@ const dirToTable = {
         data: {
           id: '18e23611-4330-4473-bbdb-02310be2ce5c',
           listing: {
-            genericName: 'crisps',
-            genericNamePlural: 'crisps',
             id: '46ced0c0-8815-4ed2-bfb6-40537f5bd512',
             image: 'walkers-cheese-onion.svg',
             listCount: 1000,
             name: 'Walkers',
             price: 30,
             qualifier: 'Cheese & Onion',
-            sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633',
-            unit: 'pack',
-            unitPlural: 'packs'
+            sellerId: '9127e1db-2a2c-41c5-908f-781ac816b633'
           },
           storeId: '1e7c9c0d-a9be-4ab7-8499-e57bf859978d',
           type: 'store-list'

--- a/item/src/client/index.ts
+++ b/item/src/client/index.ts
@@ -4,13 +4,7 @@ import fetch from '@honesty-store/service/lib/fetch';
 export interface ItemDetails {
   name: string;
   qualifier?: string;
-  genericName: string;
-  genericNamePlural: string;
-  unit: string;
-  unitPlural: string;
-  location?: string;
   image: string;
-  weight?: number;
   notes?: string;
 }
 

--- a/item/src/index.ts
+++ b/item/src/index.ts
@@ -4,7 +4,6 @@ import { v4 as uuid } from 'uuid';
 
 import {
   assertOptional,
-  assertPositiveInteger,
   assertValidString,
   createAssertValidObject,
   createAssertValidUuid
@@ -24,24 +23,14 @@ const assertValidItemId = createAssertValidUuid('itemId');
 const assertValidItemDetails = createAssertValidObject<ItemDetails>({
   name: assertValidString,
   qualifier: assertOptional(assertValidString),
-  genericName: assertValidString,
-  genericNamePlural: assertValidString,
-  unit: assertValidString,
-  unitPlural: assertValidString,
-  location: assertOptional(assertValidString),
   image: assertValidString,
-  weight: assertOptional(assertPositiveInteger),
   notes: assertOptional(assertValidString)
 });
 
-const externalise = ({ id, name, qualifier, genericName, genericNamePlural, unit, unitPlural, image }: ItemInternal): Item => ({
+const externalise = ({ id, name, qualifier, image }: ItemInternal): Item => ({
   id,
   name,
   qualifier,
-  genericName,
-  genericNamePlural,
-  unit,
-  unitPlural,
   image
 });
 

--- a/scripts/src/list-items.ts
+++ b/scripts/src/list-items.ts
@@ -27,15 +27,11 @@ const assertValidSellerId = createAssertValidUuid('sellerId');
 const assertValidAuditorId = createAssertValidUuid('auditorId');
 
 const addItem = async (itemId: string, count: number, price: number) => {
-  const { id, name, genericName, genericNamePlural, unit, unitPlural, image } = await getItem(key, itemId);
+  const { id, name, image } = await getItem(key, itemId);
 
   const storeItemListing: StoreItemListing = {
     id,
     name,
-    genericName,
-    genericNamePlural,
-    unit,
-    unitPlural,
     image,
     price,
     sellerId,

--- a/store/src/client/index.ts
+++ b/store/src/client/index.ts
@@ -4,10 +4,6 @@ import { Transaction } from '@honesty-store/transaction';
 export interface StoreItemDetails {
   name: string;
   qualifier?: string;
-  genericName: string;
-  genericNamePlural: string;
-  unit: string;
-  unitPlural: string;
   image: string;
   price: number;
 }
@@ -49,10 +45,6 @@ export interface StoreItemDetailsChanged {
   price: number;
   name: string;
   qualifier?: string;
-  genericName: string;
-  genericNamePlural: string;
-  unit: string;
-  unitPlural: string;
   image: string;
 }
 

--- a/store/src/index.ts
+++ b/store/src/index.ts
@@ -226,10 +226,6 @@ router.get<Store>(
 const storeDetailsValidator: ObjectValidator<StoreItemDetails> = {
   name: assertValidString,
   qualifier: assertOptional(assertValidString),
-  genericName: assertValidString,
-  genericNamePlural: assertValidString,
-  unit: assertValidString,
-  unitPlural: assertValidString,
   image: assertValidString,
   price: assertNonZeroPositiveInteger
 };

--- a/web/src/actions/marketplace.js
+++ b/web/src/actions/marketplace.js
@@ -27,9 +27,7 @@ const marketplaceFailure = error => {
 export const performMarketplace = ({
   description,
   totalPrice,
-  quantity,
-  location,
-  expiry
+  quantity
 }) => async (dispatch, getState) => {
   dispatch(marketplaceRequest());
 
@@ -41,9 +39,7 @@ export const performMarketplace = ({
           item: {
             description,
             totalPrice,
-            quantity,
-            location,
-            expiry
+            quantity
           }
         },
         getToken: () => getState().accessToken,

--- a/web/src/admin/item/details.js
+++ b/web/src/admin/item/details.js
@@ -7,22 +7,10 @@ export default class EditItemDetails extends React.Component {
   constructor(props) {
     super(props);
     const { item } = this.props;
-    const {
-      name,
-      qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
-      image
-    } = item || {};
+    const { name, qualifier, image } = item || {};
     this.state = {
       name,
       qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
       image
     };
   }
@@ -39,15 +27,7 @@ export default class EditItemDetails extends React.Component {
   }
 
   render() {
-    const {
-      name,
-      qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
-      image
-    } = this.state;
+    const { name, qualifier, image } = this.state;
     const { left } = this.props;
     return (
       <Full left={left}>
@@ -63,30 +43,6 @@ export default class EditItemDetails extends React.Component {
               id="qualifier"
               description="Qualifier"
               value={qualifier}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="genericName"
-              description="Category"
-              value={genericName}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="genericNamePlural"
-              description="Category plural"
-              value={genericNamePlural}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="unit"
-              description="Unit"
-              value={unit}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="unitPlural"
-              description="Unit plural"
-              value={unitPlural}
               handler={e => this.updateState(e)}
             />
             <FormElement

--- a/web/src/admin/listing/edit.js
+++ b/web/src/admin/listing/edit.js
@@ -12,23 +12,10 @@ class EditListingDetails extends React.Component {
   constructor(props) {
     super(props);
     const { details } = this.props;
-    const {
-      name,
-      qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
-      image,
-      price
-    } = details || {};
+    const { name, qualifier, image, price } = details || {};
     this.state = {
       name,
       qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
       image,
       price
     };
@@ -58,16 +45,7 @@ class EditListingDetails extends React.Component {
   }
 
   render() {
-    const {
-      name,
-      qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
-      image,
-      price
-    } = this.state;
+    const { name, qualifier, image, price } = this.state;
     const { params: { code } } = this.props;
     return (
       <Full
@@ -85,30 +63,6 @@ class EditListingDetails extends React.Component {
               id="qualifier"
               description="Qualifier"
               value={qualifier}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="genericName"
-              description="Category"
-              value={genericName}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="genericNamePlural"
-              description="Category plural"
-              value={genericNamePlural}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="unit"
-              description="Unit"
-              value={unit}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="unitPlural"
-              description="Unit plural"
-              value={unitPlural}
               handler={e => this.updateState(e)}
             />
             <FormElement

--- a/web/src/admin/listing/new.js
+++ b/web/src/admin/listing/new.js
@@ -13,10 +13,6 @@ class NewListingDetails extends React.Component {
     const {
       name,
       qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
       image,
       price,
       sellerId,
@@ -25,10 +21,6 @@ class NewListingDetails extends React.Component {
     this.state = {
       name,
       qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
       image,
       price,
       sellerId,
@@ -58,18 +50,7 @@ class NewListingDetails extends React.Component {
   }
 
   render() {
-    const {
-      name,
-      qualifier,
-      genericName,
-      genericNamePlural,
-      unit,
-      unitPlural,
-      image,
-      price,
-      sellerId,
-      listCount
-    } = this.state;
+    const { name, qualifier, image, price, sellerId, listCount } = this.state;
     const { params: { code } } = this.props;
     return (
       <Full
@@ -87,30 +68,6 @@ class NewListingDetails extends React.Component {
               id="qualifier"
               description="Qualifier"
               value={qualifier}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="genericName"
-              description="Category"
-              value={genericName}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="genericNamePlural"
-              description="Category plural"
-              value={genericNamePlural}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="unit"
-              description="Unit"
-              value={unit}
-              handler={e => this.updateState(e)}
-            />
-            <FormElement
-              id="unitPlural"
-              description="Unit plural"
-              value={unitPlural}
               handler={e => this.updateState(e)}
             />
             <FormElement

--- a/web/src/format/item.js
+++ b/web/src/format/item.js
@@ -1,4 +1,0 @@
-export default name => {
-  const possesiveChars = name.substring(name.length - 1) === 's' ? `'` : `'s`;
-  return `${name}${possesiveChars}`;
-};

--- a/web/src/item/detail.js
+++ b/web/src/item/detail.js
@@ -3,9 +3,6 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import history from '../history';
 import { BackToPage } from '../chrome/link';
-import Currency from '../format/Currency';
-import formatDate from '../format/date';
-import makePossessive from '../format/item';
 import { performPurchase } from '../actions/purchase';
 import { performUnlikeItem, performLikeItem } from '../actions/like-item';
 import isRegistered from '../reducers/is-registered-user';
@@ -31,16 +28,10 @@ const ItemDetail = ({
     price: { breakdown, total },
     image,
     count,
-    unit,
-    unitPlural,
     qualifier,
     notes,
-    weight,
-    location,
     isMarketplace,
-    isLiked,
-    expiry,
-    genericName
+    isLiked
   },
   balance,
   performLikeItem,
@@ -49,11 +40,6 @@ const ItemDetail = ({
   registered
 }) => {
   const calculateBalanceRemaining = numItems => balance - total * numItems;
-
-  const payForText = count =>
-    count !== 1
-      ? `Pay for ${count} ${unitPlural}`
-      : <span>Pay <Currency amount={total} /> for 1 {unit}</span>;
 
   const onClick = numItems => {
     const balance = calculateBalanceRemaining(numItems);
@@ -76,13 +62,13 @@ const ItemDetail = ({
 
   const registeredPurchaseButton = (
     <Link className={buttonClasses} onClick={() => onClick(1)}>
-      {payForText(1)}
+      Pay
     </Link>
   );
 
   const unregisteredPurchaseButton = (
     <Link className={buttonClasses} to={`/register/${id}`}>
-      {payForText(1)}
+      Pay
     </Link>
   );
 
@@ -115,9 +101,6 @@ const ItemDetail = ({
           </div>
           {notes && <p>{notes}</p>}
           <ul className="list-reset">
-            {weight && <li>Weight: <strong>{`${weight}g`}</strong></li>}
-            {location && <li>Location: <strong>{location}</strong></li>}
-            {expiry && <li>Expires: <strong>{formatDate(expiry)}</strong></li>}
             <li>Remaining: <strong>{count}</strong></li>
           </ul>
           <div>
@@ -127,7 +110,7 @@ const ItemDetail = ({
           </div>
           <div>
             <h4 className="mt3">Price Breakdown</h4>
-            <p>Your {makePossessive(genericName)} journey to you</p>
+            <p>Its journey to you</p>
             <Breakdown breakdown={breakdown} isMarketplace={isMarketplace} />
           </div>
           <div className="mt3 mb1">

--- a/web/src/item/success.js
+++ b/web/src/item/success.js
@@ -4,12 +4,9 @@ import { connect } from 'react-redux';
 import { Success } from '../layout/alert';
 import safeLookupItemImage from './safeLookupItemImage';
 
-export const ItemPurchaseSuccess = ({
-  item: { id, image, genericName, genericNamePlural },
-  quantity
-}) => (
+export const ItemPurchaseSuccess = ({ item: { id, image }, quantity }) => (
   <Success
-    title={`Enjoy your ${Number(quantity) === 1 ? genericName : genericNamePlural}!`}
+    title="Enjoy!"
     subtitle="Thank you for your honesty!"
     image={safeLookupItemImage(image)}
     onClick={() => history.replace(`/item/${id}`)}

--- a/web/src/marketplace/index.js
+++ b/web/src/marketplace/index.js
@@ -45,8 +45,7 @@ const Index = () => (
     </ul>
     <h2 className="mt3">What Next?</h2>
     <p>
-      To list the items we need to take a few details (description, cost and
-      location e.g. your desk, a fridge, etc.). We'll review the
+      To list the items we need to take a few details (description, cost, e.t.c). We'll review the
       submission, add the listing and then notify you and the agent.
     </p>
     <p>

--- a/web/src/marketplace/new.js
+++ b/web/src/marketplace/new.js
@@ -6,14 +6,6 @@ import { BackToPage } from '../chrome/link';
 import Full from '../layout/full';
 
 const ourFees = 0.1;
-const expiryLimitYears = 6;
-
-const extractYYYYMMDDFromDate = date => date.toISOString().split('T')[0];
-
-const addYears = (date, years) => {
-  date.setFullYear(date.getFullYear() + years);
-  return date;
-};
 
 class MarketplaceItemAdd extends React.Component {
   constructor(props) {
@@ -23,8 +15,6 @@ class MarketplaceItemAdd extends React.Component {
       description: '',
       totalPrice: '',
       quantity: '',
-      location: '',
-      expiry: '',
       validity: 'not-submitted'
     };
   }
@@ -47,29 +37,13 @@ class MarketplaceItemAdd extends React.Component {
     });
   }
 
-  handleLocationChange(event) {
-    this.setState({
-      location: event.target.value
-    });
-  }
-
-  handleExpiryChange(event) {
-    this.setState({
-      expiry: event.target.value
-    });
-  }
-
   handleSubmit(event) {
     event.preventDefault();
 
     const { performMarketplace } = this.props;
-    const { description, totalPrice, quantity, location, expiry } = this.state;
+    const { description, totalPrice, quantity } = this.state;
 
-    const validity = description.length &&
-      totalPrice.length &&
-      quantity.length &&
-      location.length &&
-      expiry.length
+    const validity = description.length && totalPrice.length && quantity.length
       ? 'valid'
       : 'invalid';
 
@@ -79,9 +53,7 @@ class MarketplaceItemAdd extends React.Component {
       performMarketplace({
         description,
         totalPrice,
-        quantity,
-        location,
-        expiry
+        quantity
       });
     }
   }
@@ -96,10 +68,6 @@ class MarketplaceItemAdd extends React.Component {
 
   render() {
     const { validity } = this.state;
-    const minDate = extractYYYYMMDDFromDate(new Date());
-    const maxDate = extractYYYYMMDDFromDate(
-      addYears(new Date(), expiryLimitYears)
-    );
 
     return (
       <Full left={<BackToPage path="/more" title="Marketplace" />}>
@@ -145,30 +113,6 @@ class MarketplaceItemAdd extends React.Component {
               type="number"
               min="1"
               step="1"
-            />
-          </p>
-          <p>
-            <label htmlFor="location">Location</label>
-            <input
-              id="location"
-              placeholder="Fridge"
-              onChange={e => this.handleLocationChange(e)}
-              value={this.state.location}
-              className="input"
-              noValidate
-            />
-          </p>
-          <p>
-            <label htmlFor="expiry">Expiry Date</label>
-            <input
-              id="expiry"
-              onChange={e => this.handleExpiryChange(e)}
-              min={minDate}
-              max={maxDate}
-              value={this.state.expiry}
-              className="input"
-              noValidate
-              type="date"
             />
           </p>
           <p>


### PR DESCRIPTION
Closes #784 

Might want to remove `genericName`, `genericNamePlural`, `unit` and `unitPlural` from `store` and `item` DB items. 