### PR TITLE
fix: bump topup lambda timeout to fix missing transactions

### DIFF
--- a/aws/src/script/deploy.ts
+++ b/aws/src/script/deploy.ts
@@ -49,7 +49,7 @@ const lambdaConfig: LambdaConfig = {
     handler: 'lib/bundle-min.handler',
     codeFilter: 'lib/bundle-min.js',
     withStripe: true,
-    timeout: 10
+    timeout: 30
   },
   user: {
     database: 'rw',


### PR DESCRIPTION
This isn't the proper fix but should fix it in most cases.